### PR TITLE
add space and removed unused function.

### DIFF
--- a/Common/kmbDebug.h
+++ b/Common/kmbDebug.h
@@ -52,29 +52,29 @@ REVOCAP_Debug_X 詳細なデバッグ用メッセージＸ（必ず出力）
 	#define REVOCAP_Debug_X(format)
 #else
 	/* _DEBUG マクロに関係なく出力 */
-	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+	#define REVOCAP_Debug_X(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
 
 	#if defined _DEBUG || _DEBUG_
 	#include <cstdio>
-	#define REVOCAP_Debug(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+	#define REVOCAP_Debug(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
 	#else
 	#define REVOCAP_Debug(format, ...)
 	#endif
 
 	#if ( _DEBUG >= 1 ) || ( _DEBUG_ >= 1 )
-	#define REVOCAP_Debug_1(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+	#define REVOCAP_Debug_1(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
 	#else
 	#define REVOCAP_Debug_1(format, ...)
 	#endif
 
 	#if ( _DEBUG >= 2 ) || ( _DEBUG_ >= 2 )
-	#define REVOCAP_Debug_2(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+	#define REVOCAP_Debug_2(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
 	#else
 	#define REVOCAP_Debug_2(format, ...)
 	#endif
 
 	#if ( _DEBUG >= 3 ) || ( _DEBUG_ >= 3 )
-	#define REVOCAP_Debug_3(fmt, ...) fprintf(stderr,"%s, line %d: "fmt,__FILE__,__LINE__, ##__VA_ARGS__)
+	#define REVOCAP_Debug_3(fmt, ...) fprintf(stderr,"%s, line %d: " fmt,__FILE__,__LINE__, ##__VA_ARGS__)
 	#else
 	#define REVOCAP_Debug_3(format, ...)
 	#endif

--- a/Geometry/kmbBucket.h
+++ b/Geometry/kmbBucket.h
@@ -348,12 +348,6 @@ public:
 
 		int getIndex() const{ return it->first; };
 
-		void getIndices(int &i,int &j,int &k) const{
-			i = it->first / (ynum*znum);
-			j = (it->first - i*ynum*znum) / znum;
-			k = it->first - i*ynum*znum - j*znum;
-		};
-
 		iterator& operator++(void){ ++it; return *this; };
 
 		iterator  operator++(int n){
@@ -390,12 +384,6 @@ public:
 		const T& get(void) const{ return it->second; };
 
 		int getIndex() const{ return it->first; };
-
-		void getIndices(int &i,int &j,int &k) const{
-			i = it->first / (ynum*znum);
-			j = (it->first - i*ynum*znum) / znum;
-			k = it->first - i*ynum*znum - j*znum;
-		};
 
 		const_iterator& operator++(void){ ++it; return *this; };
 


### PR DESCRIPTION
Hello. I found an error building `revocap-refiner`, so I suggest sourse fixes.
Could you check if it is the right fix?

- error
```
  >> 28    Common/kmbDebug.h:55:66: error: invalid suffix on literal; C++11 requires a space between literal and identifier [-Wreserved-user-defined-literal]
```
I added a space between literal and identifier.
I removed unused function `getIndices`.
